### PR TITLE
`tail -f` -> `tail -F`

### DIFF
--- a/index.js
+++ b/index.js
@@ -109,7 +109,7 @@ Handler.prototype.getLogPathStream = function(callback) {
     container itself (`docker stop` hangs forever).
     */
     setTimeout(function() {
-        self.container.exec({Cmd: ['tail', '-f', logPath], AttachStdout: true, AttachStderr: true}, function(err, exec) {
+        self.container.exec({Cmd: ['tail', '-F', logPath], AttachStdout: true, AttachStderr: true}, function(err, exec) {
             if (err) {
                 return callback(err)
             }


### PR DESCRIPTION
Will reopen the file, if it has been renamed/rotated or similar.

We've seen dukaluk stop transmitting tailed logs to logstash in our
production environment at Billy, when new containers have replaced old ones. This
should fix that.